### PR TITLE
Make start/end date flags optional and support variable date ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@
 ## HRTChart
 
 - Tracking HRT
-run: `go run hrtfunct.go --start-day=yyyy-mm-dd --file-name=filename`
+- `--start-day` and `--end-day` are optional.
+- run: `go run hrtfunct.go --start-day=yyyy-mm-dd --end-day=yyyy-mm-dd --file-name=filename`

--- a/hrtfunct.go
+++ b/hrtfunct.go
@@ -12,17 +12,37 @@ import (
 )
 
 func main() {
-	// 1. Parse the "start-day" flag from the command line
-	startDayStr := flag.String("start-day", "2024-01-01", "Specify the start day in YYYY-MM-DD format")
+	// 1. Parse optional date flags from the command line
+	startDayStr := flag.String("start-day", "", "Optional start day in YYYY-MM-DD format (defaults to today)")
+	endDayStr := flag.String("end-day", "", "Optional end day in YYYY-MM-DD format (defaults to start day + 27 days)")
 	fileNameStr := flag.String("file-name", "hrtschedule.xlsx", "Enter file name and format")
 	flag.Parse()
-	var fullFileName = fmt.Sprintf("%s%s.%s", *fileNameStr, *startDayStr, "xlsx")
 
-	// 2. Convert the provided string into a time.Time object
-	startDate, err := time.Parse("2006-01-02", *startDayStr)
-	if err != nil {
-		log.Fatalf("Invalid start day format: %v", err)
+	now := time.Now()
+	startDate := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	if *startDayStr != "" {
+		parsedStartDate, err := time.Parse("2006-01-02", *startDayStr)
+		if err != nil {
+			log.Fatalf("invalid start day format: %v", err)
+		}
+		startDate = parsedStartDate
 	}
+
+	endDate := startDate.AddDate(0, 0, 27)
+	if *endDayStr != "" {
+		parsedEndDate, err := time.Parse("2006-01-02", *endDayStr)
+		if err != nil {
+			log.Fatalf("invalid end day format: %v", err)
+		}
+		endDate = parsedEndDate
+	}
+	if endDate.Before(startDate) {
+		log.Fatalf("invalid date range: end day (%s) cannot be before start day (%s)", endDate.Format("2006-01-02"), startDate.Format("2006-01-02"))
+	}
+
+	totalDays := int(endDate.Sub(startDate).Hours()/24) + 1
+
+	var fullFileName = fmt.Sprintf("%s%s.%s", *fileNameStr, startDate.Format("2006-01-02"), "xlsx")
 
 	// Create a new Excel file
 	f := excelize.NewFile()
@@ -62,8 +82,8 @@ func main() {
 		},
 	})
 
-	// 3. Generate rows for Days 1..28, using the user-provided start date
-	for day := 1; day <= 28; day++ {
+	// 3. Generate rows for the date range.
+	for day := 1; day <= totalDays; day++ {
 		row := day + 1 // row 2..29 in the sheet
 
 		// A) Day
@@ -143,5 +163,5 @@ func main() {
 	}
 
 	log.Printf("Spreadsheet generated successfully: %s", fullFileName)
-	reportutil.CreateHormonesDoc(*fileNameStr, startDate)
+	reportutil.CreateHormonesDoc(*fileNameStr, startDate, totalDays)
 }

--- a/reportutil/reportutil.go
+++ b/reportutil/reportutil.go
@@ -97,7 +97,7 @@ func CreateHormonesSpreadsheet(filename string, startDate time.Time) error {
 // CreateHormonesDoc generates a Word document (DOCX) with 5 columns:
 // Day, Date, Hormones (multiline), Amount, and Notes.
 // The days go from 1 to 28, and the "Date" is calculated from startDate for each day.
-func CreateHormonesDoc(filename string, startDate time.Time) error {
+func CreateHormonesDoc(filename string, startDate time.Time, totalDays int) error {
 	// Ensure the filename ends with .doc
 	if !strings.HasSuffix(filename, ".docx") {
 		filename += ".docx"
@@ -130,7 +130,7 @@ func CreateHormonesDoc(filename string, startDate time.Time) error {
 	}
 
 	// ✅ Add actual data rows
-	for day := 1; day <= 28; day++ {
+	for day := 1; day <= totalDays; day++ {
 		row := table.AddRow()
 		amountText := calendardata.GetAmountTextDoc(day)
 


### PR DESCRIPTION
### Motivation
- Allow users to omit `--start-day` and `--end-day` so the tool can default to a sensible date range without requiring flags.
- Support generating charts for arbitrary contiguous date ranges instead of always using a fixed 28-day window.

### Description
- Updated CLI parsing in `hrtfunct.go` to add optional `--start-day` and `--end-day` flags where `--start-day` defaults to today and `--end-day` defaults to `start + 27 days` when omitted.
- Added validation to ensure `end-day` is not before `start-day` and compute `totalDays` via `endDate.Sub(startDate)` to determine how many rows to generate.
- Switched the Excel row generation loop in `hrtfunct.go` from a fixed 28 iterations to `totalDays` and updated the output filename to include the formatted start date.
- Changed `reportutil.CreateHormonesDoc` signature to `CreateHormonesDoc(filename string, startDate time.Time, totalDays int)` and updated its internal loop to use `totalDays` so the generated DOCX matches the spreadsheet range.
- Documented the optional flags and new usage in `README.md`.

### Testing
- Ran formatting with `gofmt -w hrtfunct.go reportutil/reportutil.go` successfully.
- Ran `go test ./...` which completed; packages report `[no test files]` indicating no unit tests are present but `go test` ran without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0dc0590d88326bb09aa4b8aa0a0a1)